### PR TITLE
Add support for xenserver neutron external CI

### DIFF
--- a/devstack-vm-gate-wrap.sh
+++ b/devstack-vm-gate-wrap.sh
@@ -416,7 +416,7 @@ fi
 if ! function_exists "gate_hook"; then
     # the command we use to run the gate
     function gate_hook {
-        $BASE/new/devstack-gate/devstack-vm-gate.sh
+        $WORKSPACE/devstack-gate/devstack-vm-gate.sh
     }
     export -f gate_hook
 fi


### PR DESCRIPTION
Remove "FORCE=yes" to align with openstack-infro/devstack-gate upstream
Move FLAT_NETWORK_BRIDGE item to pre_test_hook when neutron is used
Set gate_hook link to our repo(under $WORKSPACE)'s devstack-vm-gate.sh
